### PR TITLE
local.conf: add BBFILE_PRIORITY_meta-aws = "99"

### DIFF
--- a/biga_image/repo_seed/ami/local.conf
+++ b/biga_image/repo_seed/ami/local.conf
@@ -123,7 +123,7 @@ IMAGE_INSTALL:append = " \
 IMAGE_LINGUAS = "en-us"
 GLIBC_GENERATE_LOCALES = "en_US.UTF-8"
 
-# IMAGE_INSTALL:append = " greengrass-bin aws-cli" 
+# IMAGE_INSTALL:append = " greengrass-bin aws-cli"
 
 IMAGE_INSTALL:append = " greengrass-bin-demo"
 IMAGE_INSTALL:append  = " iproute2 canutils "
@@ -139,3 +139,6 @@ GGV2_CRED_EP     = "cuwdfxcv55sfy.credentials.iot.us-west-2.amazonaws.com"
 GGV2_REGION      = "us-west-2"
 GGV2_THING_NAME  = "vCar"
 GGV2_TES_RALIAS  = "GGTokenExchangeRoleAlias"
+
+# this will force bitbake to use meta-aws crt recipe over ROS ones
+BBFILE_PRIORITY_meta-aws = "99"

--- a/biga_image/repo_seed/device/local.conf
+++ b/biga_image/repo_seed/device/local.conf
@@ -146,4 +146,5 @@ IMAGE_ROOTFS_EXTRA_SPACE = "1048576"
 
 EXTRA_IMAGE_FEATURES += "debug-tweaks tools-debug"
 
+# this will force bitbake to use meta-aws crt recipe over ROS ones
 BBFILE_PRIORITY_meta-aws = "99"


### PR DESCRIPTION
this will force bitbake to use meta-aws crt recipe over ROS ones